### PR TITLE
[added] setting to avoid wrong highlighting in longer files

### DIFF
--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -109,3 +109,4 @@ highlight def link jaiSOA Keyword
 highlight def link jaiAOS Keyword
 
 let b:current_syntax = "jai"
+syntax sync fromstart


### PR DESCRIPTION
Small setting addition so that the highlighter takes into consideration the whole file at once and avoid wrong highlighting of long comments, for example.

Before:
![Screenshot 2024-01-14 102618](https://github.com/jansedivy/jai.vim/assets/41763256/87d87e5d-39ed-4587-bbe9-c7cba7d2767e)

After:
![Screenshot 2024-01-14 102457](https://github.com/jansedivy/jai.vim/assets/41763256/60d596b8-ddcd-4ece-912b-bacf21343654)
